### PR TITLE
Fix deprecated asyncio.wait use with coroutines and deprecated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Supported models: `uvfive.steriliser.tiger`.
   - Alarm
 
 # Install
-You can install this custom component by adding this repository ([https://github.com/vaughan-zeng/uvfive_miot](https://github.com/vaughan-zeng/uvfive_miot/)) to [HACS](https://hacs.xyz/) in the settings menu of HACS first. You will find the custom component in the integration menu afterwards, look for 'uvFive MIoT device'. Alternatively, you can install it manually by copying the custom_component folder to your Home Assistant configuration folder.
+You can install this custom component by adding this repository ([https://github.com/jairbj/uvfive_miot](https://github.com/jairbj/uvfive_miot/)) to [HACS](https://hacs.xyz/) in the settings menu of HACS first. You will find the custom component in the integration menu afterwards, look for 'uvFive MIoT device'. Alternatively, you can install it manually by copying the custom_component folder to your Home Assistant configuration folder.
 
 # Config
 

--- a/custom_components/uvfive/__init__.py
+++ b/custom_components/uvfive/__init__.py
@@ -35,8 +35,7 @@ async def async_setup_device_entry(hass: core.HomeAssistant, entry: config_entri
     if not platforms:
         return False
 
-    for platform in platforms:
-        hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, platform))
+    await hass.config_entries.async_forward_entry_setups(entry, platforms)
 
     return True
 

--- a/custom_components/uvfive/manifest.json
+++ b/custom_components/uvfive/manifest.json
@@ -13,5 +13,5 @@
   "codeowners": [
     "@von"
   ],
-  "version": "v0.1.2"
+  "version": "v0.1.3"
 }

--- a/custom_components/uvfive/manifest.json
+++ b/custom_components/uvfive/manifest.json
@@ -6,12 +6,12 @@
   "documentation": "https://github.com/vaughan-zeng/uvfive_miot",
   "issue_tracker": "https://github.com/vaughan-zeng/uvfive_miot/issues",
   "requirements": [
-    "construct",
-    "python-miio>=0.5.3"
+    "construct==2.10.70",
+    "python-miio>=0.5.12"
   ],
   "dependencies": [],
   "codeowners": [
     "@von"
   ],
-  "version": "v0.1"
+  "version": "v0.1.2"
 }

--- a/custom_components/uvfive/switch.py
+++ b/custom_components/uvfive/switch.py
@@ -144,10 +144,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         "Loading Five MIoT device via platform setup is deprecated; Please remove it from your configuration"
     )
     hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data=config,
+        asyncio.create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data=config,
+            )
         )
     )
 
@@ -209,7 +211,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 if not hasattr(device, method["method"]):
                     continue
                 await getattr(device, method["method"])(**params)
-                update_tasks.append(device.async_update_ha_state(True))
+                update_tasks.append(asyncio.create_task(device.async_update_ha_state(True)))
 
             if update_tasks:
                 await asyncio.wait(update_tasks)


### PR DESCRIPTION
I don't know exactly how it started but when using any service of this extension I got an error "TypeError: Passing coroutines is forbidden, use tasks explicitly."

This PR fixes it.